### PR TITLE
pass on go version to shared workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,13 @@ name: validate
 
 on:
   workflow_call:
+    inputs:
+      go-version:
+        type: string
+        required: false
+        description: 'The version of Go to be installed'
+        default: '1.17.13'
+
 
 jobs:
   validate:
@@ -16,6 +23,8 @@ jobs:
           pip install pre-commit
       - name: Set up Go
         uses: actions/setup-go@v3
+          with:
+            go-version: ${{ inputs.go-version }}
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,9 +6,8 @@ on:
       go-version:
         type: string
         required: false
-        description: 'The version of Go to be installed'
-        default: '1.17.13'
-
+        description: "The version of Go to be installed"
+        default: "1.17.13"
 
 jobs:
   validate:
@@ -23,8 +22,8 @@ jobs:
           pip install pre-commit
       - name: Set up Go
         uses: actions/setup-go@v3
-          with:
-            go-version: ${{ inputs.go-version }}
+        with:
+          go-version: ${{ inputs.go-version }}
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
In its current state, the `validate` shared workflow only installs the default go version (1.17.13) set by the `setup-go` GHA. However, not all of our repos that utilize the shared workflow are compatible with this version. This PR seeks to mitigate this by allowing the repos pass their desired go version along.

- Create a new input called `go-version`
- Let this new input be used by the `setup-go` GHA

Example of successful use: https://github.com/trussworks/legendary-waddle/pull/782