### PR TITLE
Autocommit and push pre-commit changes in GHA

### DIFF
--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -43,5 +43,6 @@ jobs:
       - uses: pre-commit/action@v3.0.0
 
       - uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ failure() }}
         with:
           commit_message: Commit changes made by pre-commit

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ steps.load-pat-secret.outputs.PAT_SECRET }}
+          token: ${{ env.PAT_SECRET }}
 
       - name: Render terraform docs and push changes back to PR
         uses: terraform-docs/gh-actions@main

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -24,7 +24,7 @@ jobs:
         id: load-pat-secret
         uses: 1password/load-secrets-action@v1
         env:
-          PAT_SECRET: op://Infra/"Github - trussworks-infra"/validate-tf-token
+          PAT_SECRET: op://Infra/"Github - trussworks-infra"/credentials/validate-tf-token
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -24,7 +24,7 @@ jobs:
         id: load-pat-secret
         uses: 1password/load-secrets-action@v1
         env:
-          PAT_SECRET: op://Infra/"Github - trussworks-infra"/credentials/validate-tf-token
+          PAT_SECRET: "op://Infra/Github - trussworks-infra/validate-tf-token"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -2,9 +2,9 @@ name: Validate - Terraform
 
 on:
   workflow_call:
-  pull_request:
-  push:
-    branches: [main]
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: true
 
 jobs:
   validate-tf:

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -9,11 +9,29 @@ on:
 jobs:
   validate-tf:
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
     steps:
+      - name: Configure 1Password Service Account
+        uses: 1password/load-secrets-action/configure@v1
+        with:
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Load PAT secret
+        id: load-pat-secret
+        uses: 1password/load-secrets-action@v1
+        env:
+          PAT_SECRET: op://Infra/"Github - trussworks-infra"/validate-tf-token
+
       - uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.load-pat-secret.outputs.PAT_SECRET }}
+
       - name: Render terraform docs and push changes back to PR
         uses: terraform-docs/gh-actions@main
         with:
@@ -21,4 +39,9 @@ jobs:
           output-file: README.md
           output-method: inject
           git-push: "true"
+
       - uses: pre-commit/action@v3.0.0
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Commit changes made by pre-commit


### PR DESCRIPTION
## [Add the ability to commit and push changes made by terraform-fmt in the validate-tf GHA workflow](https://trello.com/c/s1jfNe0K)

Changes proposed in this pull request:

- See https://github.com/trussworks/terraform-aws-bootstrap/pull/109
- Add steps to pull PAT from 1Password and autocommit if precommit fails
