### PR TITLE
fix: uses setup-python which is required for pre-commit action

### DIFF
--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -21,4 +21,7 @@ jobs:
           output-file: README.md
           output-method: inject
           git-push: "true"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
An attempt to fix [this](https://github.com/trussworks/terraform-aws-iam-sleuth/actions/runs/12718887362/job/35458111929?pr=407)
[pre-commit action](https://github.com/pre-commit/action)
[setup-python action](https://github.com/actions/setup-python)
