### PR TITLE
fix: install tfdocs manually and put in PATH

### DIFF
--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -14,8 +14,14 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+      - name: Install terraform-docs
+        run: |
+          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.19.0/terraform-docs-v0.19.0-linux-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          sudo mv terraform-docs /usr/local/bin/
       - name: Render terraform docs and push changes back to PR
-        uses: terraform-docs/gh-actions@main
+        uses: terraform-docs/gh-actions@v1.3.0
         with:
           working-dir: .
           output-file: README.md


### PR DESCRIPTION
An attempt to fix [this](https://github.com/trussworks/terraform-aws-iam-sleuth/actions/runs/12719267682/job/35459182417?pr=407) which errors with

```bash
ERROR: terraform-docs is required by terraform_docs pre-commit hook but is not installed or in the system's PATH.
```
