### PR TITLE
chore: remove terrible github action

### DIFF
--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -20,13 +20,6 @@ jobs:
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
           sudo mv terraform-docs /usr/local/bin/
-      - name: Render terraform docs and push changes back to PR
-        uses: terraform-docs/gh-actions@v1.3.0
-        with:
-          working-dir: .
-          output-file: README.md
-          output-method: inject
-          git-push: "true"
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'


### PR DESCRIPTION
We end up with terrible PR like this https://github.com/trussworks/terraform-aws-iam-sleuth/pull/408/files with this module. Removing the action.
