### PR TITLE
feat: hashicorp/setup-terraform action added to validate-tf.yml workflow

### DIFF
--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - name: Install terraform-docs
         run: |
           curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.19.0/terraform-docs-v0.19.0-linux-amd64.tar.gz


### PR DESCRIPTION
Experiencing a bunch of [this](https://github.com/trussworks/terraform-aws-iam-sleuth/actions/runs/12837381367/job/35800931776)

```bash
Terraform fmt............................................................Failed
- hook id: terraform_fmt
- exit code: 127

Neither Terraform nor OpenTofu binary could be found. Please either set the "--tf-path" hook configuration argument, or set the "PCT_TFPATH" environment variable, or set the "TERRAGRUNT_TFPATH" environment variable, or install Terraform or OpenTofu globally.
/home/runner/.cache/pre-commit/repogkja2ilc/hooks/terraform_fmt.sh: line 52: : command not found
```

So this will put the `terraform` binary in the job.
