### PR TITLE
fix: goreleaser prior to pre-commit

### DIFF
--- a/.github/workflows/validate-go.yml
+++ b/.github/workflows/validate-go.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       - name: Set up Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
@@ -27,3 +25,5 @@ jobs:
           install-only: true
       - name: Show GoReleaser version
         run: goreleaser -v
+      - name: Install pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
Trying to fix [this](https://github.com/trussworks/find-guardduty-user/actions/runs/12840369997/job/35808936810)

pre-commit expects `goreleaser` to exist, but it isn't installed yet. This ensures `goreleaser` is installed prior to running pre-commit.
