### PR TITLE
fix: a terraform-docs combination that works

### DIFF
--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -16,13 +16,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-      - name: Install terraform-docs
-        run: |
-          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.19.0/terraform-docs-v0.19.0-linux-amd64.tar.gz
-          tar -xzf terraform-docs.tar.gz
-          chmod +x terraform-docs
-          sudo mv terraform-docs /usr/local/bin/
+      - name: Render terraform docs inside the README.md
+        uses: terraform-docs/gh-actions@aeae0038ed47a547e0c0fca5c059d3335f48fb25 # v1.3.0
+        with:
+          working-dir: .
+          config-file: .terraform-docs.yml
+          output-method: ""
+          output-file: ""
+          output-format: ""
+          template: ""
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.13"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        env:
+          SKIP: ${{ vars.SKIP }}


### PR DESCRIPTION
Across the org, I've fought `terraform-docs`. Various combinations of `pre-commit` hooks, official and unofficial GitHub Actions. I believe I fixed it. You can see it work [here](https://github.com/trussworks/terraform-aws-alb-web-containers/actions/runs/13082911534).

What this does:

- Uses official GitHub Action for Terraform-Docs
- Passes an environment variable `SKIP` with a value of `terraform-system-go`. This is the `id` of the pre-commit hook in our `.pre-commit-config.yaml` files. This causes Terraform Docs to not run via Pre-Commit since it is running in the official Action.
- This also allows `terraform-docs` to continue to run locally via pre-commit.
